### PR TITLE
Speeding up tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ docs/_build/*
 build/*
 dist/
 django_memoize.egg-info/*
+.eggs/*
+.coverage

--- a/runtests.py
+++ b/runtests.py
@@ -11,7 +11,7 @@ from django.test.utils import get_runner
 if __name__ == "__main__":
     if hasattr(django, 'setup'):
         django.setup()
-        
+
     TestRunner = get_runner(settings)
     test_runner = TestRunner()
     failures = test_runner.run_tests(["tests"])

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,10 @@ basepython =
     py36: python3.6
 
 deps =
+    coverage
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
-    coverage
+    freezegun
+    mock
 
 commands=coverage run runtests.py


### PR DESCRIPTION
I find using `time.sleep` for testing expire as unnecessary slowing down the tests. 

This PR aims to fix that. 

Removed all `time.sleep` calls in the `tests.py` and uses `freezegun` in places where we need to tests expiration. 

Speed up tests by ~14s