### PR TITLE
Add support for boolean convert_to_unicode flag

### DIFF
--- a/memoize/__init__.py
+++ b/memoize/__init__.py
@@ -225,10 +225,14 @@ class Memoizer(object):
                 if isinstance(altfname, string_types):
                     altfname = text_type(altfname)
 
+                keyargs = list(keyargs)
+
                 # convert all string values in `args` to `unicode`
                 for i, elem in enumerate(keyargs):
                     if isinstance(elem, string_types):
                         keyargs[i] = text_type(elem)
+
+                keyargs = tuple(keyargs)
 
                 # we have to save the keys here as the dictionary may mutate
                 # during the course of iteration

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -576,6 +576,10 @@ class MemoizeTestCase(SimpleTestCase):
         assert without_make_name != with_make_name
 
     def test_20_memoize_convert_to_unicode(self):
+        # This feature only applies to <= Python 2.x
+        if sys.version_info >= (3, 0):
+            return
+
         # disable convert_to_unicode flag
         @self.memoizer.memoize(
             make_name=lambda fname: 'make_name',


### PR DESCRIPTION
This PR is intended to add support for a boolean `convert_to_unicode` flag, which will enable us to specify whether or not to convert string-objects to `unicode` when executing `make_cache_key` for a particular function that has been `memoized`.

**EDIT**: This PR was implemented in order to resolve the following issue when using `django-memoize` under `Python 2`:

```
In [1]: from memoize import memoize

In [2]: import random

In [3]: @memoize(timeout=300)
   ...: def f(key):
   ...:     return random.randrange(100000, 999999)
   ...:

In [4]: f('abc')
Out[4]: 656674

In [5]: f(u'abc')
Out[5]: 749955

In [6]: f('abc')
Out[6]: 656674

In [7]: f(u'abc')
Out[7]: 749955
```

...in particular, even though `'abc'` and `u'abc'` are _logically_ the same string, we create two separate cache entries simply based on the fact that one key is a `str` object and the other is a `unicode` object.

This phenomenon currently affects any piece of the library that makes use of the `make_cache_key` method (i.e. `memoize`, `delete_memoized`, etc.). For example, if we run `f('abc')` (in one file) and then run `delete_memoized(f, u'abc')` (in some other file), then the cache entry will not be properly cleared.