### PR TITLE
Remove support for convert_to_unicode option

### DIFF
--- a/memoize/__init__.py
+++ b/memoize/__init__.py
@@ -191,12 +191,7 @@ class Memoizer(object):
 
         return fname, ''.join(version_data_list)
 
-    def _memoize_make_cache_key(
-            self,
-            make_name=None,
-            timeout=DEFAULT_TIMEOUT,
-            convert_to_unicode=False
-    ):
+    def _memoize_make_cache_key(self, make_name=None, timeout=DEFAULT_TIMEOUT):
         """
         Function used to create the cache_key for memoized functions.
         """
@@ -218,41 +213,6 @@ class Memoizer(object):
                 )
             else:
                 keyargs, keykwargs = args, kwargs
-
-            # convert string-type parameters to `unicode`, if necessary
-            if convert_to_unicode:
-                # convert function name to `unicode`
-                if isinstance(altfname, string_types):
-                    altfname = text_type(altfname)
-
-                keyargs = list(keyargs)
-
-                # convert all string values in `args` to `unicode`
-                for i, elem in enumerate(keyargs):
-                    if isinstance(elem, string_types):
-                        keyargs[i] = text_type(elem)
-
-                keyargs = tuple(keyargs)
-
-                # we have to save the keys here as the dictionary may mutate
-                # during the course of iteration
-                keys = list(keykwargs.keys())
-
-                # convert all string keys in `kwargs` to `unicode`
-                for k in keys:
-                    value = keykwargs[k]
-
-                    if isinstance(k, string_types):
-                        new_k = text_type(k)
-                        keykwargs[new_k] = value
-                        # avoid doubling of keys
-                        if type(new_k) != type(k):
-                            del keykwargs[k]
-
-                # convert all string values in `kwargs` to `unicode`
-                for k, v in iteritems(keykwargs):
-                    if isinstance(v, string_types):
-                        keykwargs[k] = text_type(v)
 
             cache_key = hashlib.md5(
                 force_bytes((altfname, keyargs, keykwargs))
@@ -323,13 +283,7 @@ class Memoizer(object):
 
         return tuple(new_args), kwargs
 
-    def memoize(
-            self,
-            timeout=DEFAULT_TIMEOUT,
-            make_name=None,
-            unless=None,
-            convert_to_unicode=False
-    ):
+    def memoize(self, timeout=DEFAULT_TIMEOUT, make_name=None, unless=None):
         """
         Use this to cache the result of a function, taking its arguments into
         account in the cache key.
@@ -372,12 +326,6 @@ class Memoizer(object):
 
                     readable and writable
 
-                **convert_to_unicode**
-                    A boolean flag to enable conversion of strings to `unicode`
-                    objects. Primarily used when generating the cache_key.
-
-                    readable and writable
-
 
         :param timeout: Default: 300. If set to an integer, will cache
                         for that amount of time. Unit of time is in seconds.
@@ -388,9 +336,6 @@ class Memoizer(object):
         :param unless: Default: None. Cache will *always* execute the caching
                        facilities unless this callable is true.
                        This will bypass the caching entirely.
-        :param convert_to_unicode: Default: False. If set, will determine if
-                                   string objects are converted to `unicode`
-                                   during the cache_key generation process.
         """
 
         def memoize(f):
@@ -434,7 +379,7 @@ class Memoizer(object):
             decorated_function.uncached = f
             decorated_function.cache_timeout = timeout
             decorated_function.make_cache_key = self._memoize_make_cache_key(
-                make_name, decorated_function, convert_to_unicode
+                make_name, decorated_function
             )
             decorated_function.delete_memoized = (
                 lambda: self.delete_memoized(f)

--- a/memoize/__init__.py
+++ b/memoize/__init__.py
@@ -13,7 +13,6 @@ from django.conf import settings
 from django.core.cache import cache as default_cache
 from django.core.cache.backends.base import DEFAULT_TIMEOUT
 from django.utils.encoding import force_bytes
-from django.utils.six import text_type, string_types, iteritems
 
 logger = logging.getLogger(__name__)
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -575,40 +575,7 @@ class MemoizeTestCase(SimpleTestCase):
 
         assert without_make_name != with_make_name
 
-    def test_20_memoize_convert_to_unicode(self):
-        # This feature only applies to <= Python 2.x
-        if sys.version_info >= (3, 0):
-            return
-
-        # disable convert_to_unicode flag
-        @self.memoizer.memoize(
-            make_name=lambda fname: 'make_name',
-            convert_to_unicode=False,
-        )
-        def f(*args, **kwargs):
-            return random.randrange(0, 100000)
-
-        old_value = f('a', 'b', c='c', d='d')
-        new_value = f(u'a', u'b', c=u'c', d=u'd')
-
-        assert new_value != old_value
-
-        self.memoizer.clear()
-
-        # enable convert_to_unicode flag
-        @self.memoizer.memoize(
-            make_name=lambda fname: 'make_name',
-            convert_to_unicode=True,
-        )
-        def f(*args, **kwargs):
-            return random.randrange(0, 100000)
-
-        old_value = f('a', 'b', c='c', d='d')
-        new_value = f(u'a', u'b', c=u'c', d=u'd')
-
-        assert new_value == old_value
-
-    def test_21_memoize_unless(self):
+    def test_20_memoize_unless(self):
         @self.memoizer.memoize(unless=lambda: True)
         def f():
             return random.randrange(0, 100000)
@@ -619,7 +586,7 @@ class MemoizeTestCase(SimpleTestCase):
         assert new_value != old_value
 
     @patch('memoize.Memoizer.get', side_effect=Exception)
-    def test_22_memoize_get_backend_error(self, memoizer_get):
+    def test_21_memoize_get_backend_error(self, memoizer_get):
         logging.basicConfig()
 
         # disable logger (to avoid cluttering test output)
@@ -647,7 +614,7 @@ class MemoizeTestCase(SimpleTestCase):
         logging.disable(logging.NOTSET)
 
     @patch('memoize.Memoizer.set', side_effect=Exception)
-    def test_23_memoize_set_backend_error(self, memoizer_set):
+    def test_22_memoize_set_backend_error(self, memoizer_set):
         logging.basicConfig()
 
         # disable logger (to avoid cluttering test output)
@@ -682,7 +649,7 @@ class MemoizeTestCase(SimpleTestCase):
         # re-enable logger
         logging.disable(logging.NOTSET)
 
-    def test_24_delete_memoized_not_callable(self):
+    def test_23_delete_memoized_not_callable(self):
         warning_raised = False
 
         try:
@@ -693,7 +660,7 @@ class MemoizeTestCase(SimpleTestCase):
         assert warning_raised
 
     @patch('memoize.Memoizer.delete', side_effect=Exception)
-    def test_25_delete_memoized_backend_error(self, memoizer_delete):
+    def test_24_delete_memoized_backend_error(self, memoizer_delete):
         logging.basicConfig()
 
         # disable logger (to avoid cluttering test output)
@@ -719,7 +686,7 @@ class MemoizeTestCase(SimpleTestCase):
         # re-enable logger
         logging.disable(logging.NOTSET)
 
-    def test_26_delete_memoized_verhash_not_callable(self):
+    def test_25_delete_memoized_verhash_not_callable(self):
         warning_raised = False
 
         try:
@@ -730,7 +697,7 @@ class MemoizeTestCase(SimpleTestCase):
         assert warning_raised
 
     @patch('memoize.Memoizer.delete', side_effect=Exception)
-    def test_27_delete_memoized_verhash_backend_error(self, memoizer_delete):
+    def test_26_delete_memoized_verhash_backend_error(self, memoizer_delete):
         logging.basicConfig()
 
         # disable logger (to avoid cluttering test output)


### PR DESCRIPTION
As mentioned in https://github.com/unhaggle/django-memoize/issues/41 and https://github.com/unhaggle/django-memoize/commit/1b41517e597d34ca3fe56b11f7ea863a4283f65e#r38739933, this newly-introduced option and the associated `django.utils.six` import are breaking Django 3.x compatibility.

After some internal discussions, it's been determined that removing this option would be the most straightforward fix for now.

Closes #41.