### PR TITLE
Fix warnings in Python 3.8

### DIFF
--- a/memoize/__init__.py
+++ b/memoize/__init__.py
@@ -444,7 +444,7 @@ class Memoizer(object):
         return memoize
 
     def delete_memoized(self, f, *args, **kwargs):
-        """
+        r"""
         Deletes the specified functions caches, based by given parameters.
         If parameters are given, only the functions that were memoized with
         them will be erased. Otherwise all versions of the caches will be

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -556,9 +556,9 @@ class MemoizeTestCase(SimpleTestCase):
         argspec = _get_argspec(foo)
 
         if major_version < 3:
-            assert argspec.__class__.__name__ is 'ArgSpec'
+            assert argspec.__class__.__name__ == 'ArgSpec'
         else:
-            assert argspec.__class__.__name__ is 'FullArgSpec'
+            assert argspec.__class__.__name__ == 'FullArgSpec'
 
     def test_19_memoize_make_name(self):
         @self.memoizer.memoize()


### PR DESCRIPTION
Closes #43.